### PR TITLE
Disable preview features

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,21 +21,8 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
-                <configuration>
-                    <source>16</source>
-                    <target>16</target>
-                    <compilerArgs>--enable-preview</compilerArgs>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
-                <configuration>
-                    <argLine>--enable-preview</argLine>
-                </configuration>
             </plugin>
         </plugins>
         <resources>


### PR DESCRIPTION
Preview features aren't used by Overlord, and they make it unusable on versions of Java that are higher than Overlord's target version. This pull request removes the `--enable-preview` flag from the compiler, and also gets rid of the useless `maven-compiler-plugin` definition (The properties tags already take care of the source and target version)